### PR TITLE
Generalforsamling 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Vedtekter
+
+---
+
+## echo - Linjeforening for informatikk
+
+---
+
+Hallo alle flotte studenter som tar seg tid til å besøke vedtektene til echo!😁
+
+Vi kan sikkert skrive en hel del med ubrukelig informasjon her, men jeg oppretter denne filen kun for en enkel grunn.
+
+Vedtektene som står her er **IKKE** de offisielle vedtektene til echo. Det som sendes inn til brønnøysund er whatever
+som står i referatet.
+
+På den andre siden er vi alle informatikere, og hvorfor drive å leke rundt i word når vi faktisk vet hvordan vi bruker
+versjonskontroll systemet git?
+
+Derfor håper jeg på at dere videre kan finne på noe nytt for å effektivisere generalforsaingene til echo.
+
+Takk for meg.
+
+\- Stian

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Hallo alle flotte studenter som tar seg tid til å besøke vedtektene til echo!�
 
 Vi kan sikkert skrive en hel del med ubrukelig informasjon her, men jeg oppretter denne filen kun for en enkel grunn.
 
-Vedtektene som står her er **IKKE** de offisielle vedtektene til echo. Det som sendes inn til brønnøysund er whatever
+Vedtektene som står her er (kanskje) **IKKE** de offisielle vedtektene til echo. Det som sendes inn til brønnøysund er whatever
 som står i referatet.
 
 På den andre siden er vi alle informatikere, og hvorfor drive å leke rundt i word når vi faktisk vet hvordan vi bruker

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Derfor håper jeg på at dere videre kan finne på noe nytt for å effektivisere
 Takk for meg.
 
 \- Stian
+
+> I approve this message
+
+\-- Arne

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -36,6 +36,18 @@ I disse vedtektene betyr
 
    Person med verv i samme undergruppe.
 
+10. Simpelt flertall
+
+	Det forslaget som får flest stemmer blir vedtatt.
+
+11. alminnelig flertall
+
+	Hvis et forslag får mer enn 50% av stemmene blir det vedtatt.
+
+12. 2/3 kvalifisert flertall
+
+	Hvis et forslag får mer enn 2/3 av stemmene blir det vedtatt.
+
 ## § 1 Foreningens navn
 
 Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Foreningen kan i dagligtale og skriftlige referanser forkortes til "echo" (med liten e).
@@ -119,7 +131,7 @@ Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
 
 	c. Et slikt mistillitsforslag vil bli behandlet av hovedstyret på et hovedstyremøte. De involverte partene presenterer saken sin ved ønske, de involverte må forlate rommet under diskusjon og avstemming. Denne avstemningen er anonym, og det er nødt til å være en tredjepart, som ikke er en del av echo, som teller stemmene.
 
-	d. Hvis mistillitsforslaget blir vedtatt med 2/3-flertall mister personen plassen sin i styret.
+	d. Hvis mistillitsforslaget blir vedtatt med 2/3 kvalifisert flertall mister personen plassen sin i styret.
 
 3. Mistillitsforslag mot mer enn ett -1- medlem i hovedstyret
 
@@ -137,7 +149,7 @@ Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
 
 	b. Valgresultatet utover de folkevalgte er taushetsbelagt, og skal oppbevares av en tredjepart uavhengig av echo.
 
-	c. Innsyn kan gis til personer i og utenfor Hovedstyret, og må vedtas med 2/3 flertall på styremøte. Disse personene er underlagt taushetsplikten. Dersom begjæringen om innsyn ikke vedtas av Hovedstyret, kan søker kreve at saken tas opp på neste generalforsamling.
+	c. Innsyn kan gis til personer i og utenfor Hovedstyret, og må vedtas med 2/3 kvalifisert flertall på styremøte. Disse personene er underlagt taushetsplikten. Dersom begjæringen om innsyn ikke vedtas av Hovedstyret, kan søker kreve at saken tas opp på neste generalforsamling.
 
 3. Tidspunkter
 
@@ -211,7 +223,7 @@ Leder og ett annet styremedlem kan signere sammen.
 
 ## § 13 Vedtektsendring
 
-1. Disse vedtektene gjelder fra 7/11-95. Den sittende linjeforening har ansvaret for iverksettelsen av disse vedtektene. Disse vedtektene kan kun endres på en generalforsamling ved Institutt for informatikk på Universitetet i Bergen. Et vedtak om en endring må ha oppnådd 2/3 flertall blant de tilstedeværende stemmeberettigede.
+1. Disse vedtektene gjelder fra 7/11-95. Det sittende Hovedstyret har ansvaret for iverksettelsen av disse vedtektene. Disse vedtektene kan kun endres på en generalforsamling ved Instituttet. Et vedtak om en endring må ha oppnådd 2/3 kvalifisert flertall blant de tilstedeværende stemmeberettigede.
 2. Vedtektene ble sist endret ved generalforsamling 04.03.2024.
 3. Hovedstyret har til enhver tid myndighet til å gjøre redaksjonelle endringer i echo sine vedtekter. En redaksjonell endring er en endring vedrørende grammatikk, struktur eller ordlyd som ikke forandrer på meningen eller innholdet i originalteksten. Eventuelle endringer må protokollføres, og informeres om under neste generalforsamling.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -111,11 +111,20 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 	f. undergrupper-Rep kan gi fullmakt til verv-kamerat for å stemme.
 
-3. Vervet
+3. Frafall 
 
-	a. Representanter kan trekke seg fra sitt verv i Hovedstyret dersom det er særskilt grunn.
+	a. Representant(er) i Hovedstyret kan trekke seg fra vervet dersom det er en særskilt grunn. 
 
-	b. Hvis en representant trekker seg fra Hovedstyrets kandidatliste, skal valgalgoritmen kjøres på nytt igjen med stemmene fra foregående valg. Personen som trakk seg fjernes fra stemmesedlene, og kandidater med lavere rangering enn den som trakk seg vil da rykke opp. I det tilfelle der det nye resultatet har mer enn ett nytt styremedlem vil stemmene på alle andre kandidater enn de aktuelle personene fjernes. En kjører så algoritmen en tredje gang der kun én kandidat utnevnes. Denne kandidaten overtar for personen som trakk seg.
+	b. Representant(er) i Hovedstyret må trekke seg fra vervet i henhold til §7 Mistillit.
+4. Konsekvenser ved frafall.
+
+	a. Hvis en undergrupper-Rep fratrer som representant i Hovedstyret skal det avholdes nytt internt valg i undergruppen innen én -1- uke etter frafallet.
+
+	b. Ved frafall fra Hovedstyret kjøres valgalgoritmen igjen, med de samme stemmene som ved forrige valg. Representantene som har meldt frafall fjernes fra stemmesedlene.
+
+	Dersom resultatet gir flere nye kandidater enn ledige plasser, kjøres valgalgoritmen nok en gang; Kun med kandidatene som kvalifiserte seg til Hovedstyret i det nye valget, og som ikke allerede sitter i hovedstyret.
+
+	Resultatet av dette er de nye folkevalgte.
 
 ## § 7 Mistillit
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -201,19 +201,24 @@ Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
 	1. Bedkom skal tilby hjelp med planlegging, markedsføring og organisering av ulike arrangementer for bedrifter i samråd med hovedstyret.
 	2. Bedkom skal bedre relasjonen mellom Våre studenter og næringslivet.
 	3. Bedkom har ansvar for å arrangere bedriftstur.
-2. echo Sports Club (ESC)
+2. echo Consulting
+   1. echo Consulting skal utvikle webløsninger for eksterne organisasjoner, primært
+      frivillige- og studentorganisasjoner.
+      2. echo Consulting skal bidra til et sterkt fagmiljø blant Våre studenter, med blant annet
+         arrangementer eller relevante kurs.
+3. echo Sports Club (ESC)
 	1. ESC skal fungere som et bindeledd mellom flere idrettslag under echo, slik at det skal bli lettere å forme ulike idrettsgrupper.
 	2. ESC skal arrangere treninger og holde kurs.
-3. Gnist
+4. Gnist
 	1. Gnist arbeider med rekruttering og fullføring av studiet i samarbeid med Instituttet og Fakultetet.
 	2. Gnist arrangerer diverse faglige og sosiale arrangementer for Våre studenter.
-4. Hyggkom
+5. Hyggkom
 	1. Hyggkom fokuserer på å skape trivsel på lesesalene våre.
 	2. Hyggkom har et overordnet ansvar for forvaltning av lesesalene våre.
 	3. Hyggkom har hovedansvar for feiring av diverse høytider.
-5. Tilde
+6. Tilde
 	1. Tilde skal arrangere og gjennomføre sosiale arrangementer.
-6. Webkom
+7. Webkom
 	1. Webkom drifter og videreutvikler echo sine webløsninger, hovedsakelig nettsiden echo.uib.no
 	2. Webkom skal holde relevante kurs og arrangementer.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -56,7 +56,8 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 1. Programstudenter ved Instituttet.
 2. Post-bachelorstudenter og post-masterstudenter som tidligere har vært programstudenter ved Instituttet, som har betalt semesteravgift og tar emne(r).
 3. Ph.d.-kandidater ved Instituttet som tidligere har vært programstudenter ved Instituttet. Ved gode grunner kan hovedstyret tillate andre Ph.d.-kandidater.
-4. Ved gode grunner kan Hovedstyret tillate andre studenter, dersom de tar hovedemner ved Instituttet.
+4. Studenter som har fått godkjent en søknad av Hovedstyret, gitt at de tar hovedemner ved Instituttet.
+5. Utvekslingsstudenter som tar hovedemner ved Instituttet.
 
 ## § 3 Formål
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -20,6 +20,22 @@ I disse vedtektene betyr
 
    echo Programmerbar, org.nr.: 927307898.
 
+6. Hovedstyret
+
+   Hovedstyret er echo sin høyeste myndighet mellom generalforsamlingene.
+
+7. Folkevalgte
+
+   De representantene i Hovedstyret som velges gjennom preferansevalg.
+
+8. undergrupper-Rep
+
+   De representantene i Hovedstyret som velges fra en undergruppe.
+
+9. Verv-kamerat
+
+   Person med verv i samme undergruppe.
+
 ## § 1 Foreningens navn
 
 Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Foreningen kan i dagligtale og skriftlige referanser forkortes til "echo" (med liten e).
@@ -51,15 +67,15 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 echo har ingen medlemskontingent.
 
 ## § 6 Hovedstyret
-Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
+Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
 
 1. Styret
 	
-	a. Hovedstyret består av de folkevalgte og én -1- representant fra hver av echos undergrupper.
+	a. Hovedstyret består av de folkevalgte og én -1- undergruppe-Rep fra hver av echo sine undergrupper.
 	
 	b. Det avholdes valg av representant internt i undergruppene etter valgresultatene før de folkevalgte er offentliggjort.
 	
-	c. En person kan ikke representere mer enn én -1- undergruppe. De folkevalgte kan ikke være representant for en undergruppe.
+	c. En person kan ikke være undergruppe-Rep for mer enn én -1- undergruppe. De folkevalgte kan ikke være undergruppe-Rep.
 	
 	d. Det er kun de folkevalgte som kan velges inn som leder, nestleder, økonomiansvarlig og økonomiassistent.
 
@@ -69,7 +85,7 @@ Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 
 	a. Hovedstyret avgjør selv møtehyppigheten.
 
-	b. Hovedstyret er vedtaksdyktig dersom mer enn 50% av utvalgets medlemmer er tilstede.
+	b. Hovedstyret er vedtaksdyktig dersom mer enn 50% av Hovedsturet sine representanter er til stede.
 
 	c. Vedtak fattes ved simpelt flertall. Ved stemmelikhet har leder dobbeltstemme.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -28,7 +28,7 @@ I disse vedtektene betyr
 
    De representantene i Hovedstyret som velges gjennom preferansevalg.
 
-8. undergrupper-Rep
+8. UG-Rep
 
    De representantene i Hovedstyret som velges fra en undergruppe.
 
@@ -87,7 +87,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 	
 	a. Hovedstyret består av de folkevalgte og én -1- undergruppe-Rep fra hver av echo sine undergrupper.
 	
-	b. I forbindelse med det ordinære valget skal det velges en undergrupper-rep fra hver undergruppe. undergrupper-Rep skal velges etter offentliggjøringen av valgresultatet, og senest innen én - 1 - uke.
+	b. I forbindelse med det ordinære valget skal det velges en UG-Rep fra hver undergruppe. UG-Rep skal velges etter offentliggjøringen av valgresultatet, og senest innen én - 1 - uke.
 	
 	c. En person kan ikke være undergruppe-Rep for mer enn én -1- undergruppe. De folkevalgte kan ikke være undergruppe-Rep.
 	
@@ -101,7 +101,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 	a. Hovedstyret avgjør selv møtehyppigheten.
 
-	b. Hovedstyret er vedtaksdyktig dersom mer enn 50% av Hovedsturet sine representanter er til stede.
+	b. Hovedstyret er vedtaksdyktig dersom mer enn 50% av Hovedstyret sine representanter er til stede.
 
 	c. Vedtak fattes ved simpelt flertall. Ved stemmelikhet har leder dobbeltstemme.
 
@@ -109,7 +109,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 	e. En representant fra hver av echos undergrupper har møterett på Hovedstyrets møter.
 
-	f. undergrupper-Rep kan gi fullmakt til verv-kamerat for å stemme.
+	f. UG-Rep kan gi fullmakt til verv-kamerat for å stemme.
 
 3. Frafall 
 
@@ -118,7 +118,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 	b. Representant(er) i Hovedstyret må trekke seg fra vervet i henhold til §7 Mistillit.
 4. Konsekvenser ved frafall.
 
-	a. Hvis en undergrupper-Rep fratrer som representant i Hovedstyret skal det avholdes nytt internt valg i undergruppen innen én -1- uke etter frafallet.
+	a. Hvis en UG-Rep fratrer som representant i Hovedstyret skal det avholdes nytt internt valg i undergruppen innen én -1- uke etter frafallet.
 
 	b. Ved frafall fra Hovedstyret kjøres valgalgoritmen igjen, med de samme stemmene som ved forrige valg. Representantene som har meldt frafall fjernes fra stemmesedlene.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -199,11 +199,10 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 ## § 9 Generalforsamling
 1. Generalforsamling er organisasjonens høyeste organ.
-2. Det innkalles til generalforsamling med minst to -2- ukers varsel.
-3. Generalforsamlingen skal ha en saksliste. Foreløpig saksliste skal gjøres kjent for Våre studenter samtidig med innkalling.
-4. Generalforsamlingen kan ikke behandle forslag som ikke er oppført på sakslisten, med
-   mindre det blir godkjent av et alminnelig flertall av de stemmeberettigede som er tilstede.
-5. Vedtak fattes med simpelt flertall av de stemmeberettigede som er tilstede, forutsatt at antall stemmeberettigede overstiger tyve -20-.
+2. Det innkalles til generalforsamling med minst to -2- ukers varsel. Det skal innkalles på echo sin nettside og plakater ved Instituttet.
+3. Generalforsamlingen skal ha en saksliste. Hovedstyret sin saksliste skal gjøres kjent for Våre studenter samtidig med innkalling.
+4. Generalforsamlingen kan ikke behandle forslag som ikke er oppført på sakslisten, med mindre det blir godkjent av et alminnelig flertall av de stemmeberettigede som er tilstede.
+5. Vedtak fattes med alminnelig flertall av de stemmeberettigede som er tilstede, forutsatt at antall stemmeberettigede overstiger tyve -20-.
 6. Forslag til saker som skal opp på generalforsamlingen må fremmes til Hovedstyret minst fire -4- virkedager før generalforsamlingen skal holdes.
 7. Tre -3- virkedager før generalforsamlingen skal endelig saksliste offentliggjøres.
 8. Ordinær generalforsamling
@@ -214,9 +213,9 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 9. Ekstraordinær generalforsamling
 
-	a. Generalforsamling skal arrangeres når Hovedstyret mener at det foreligger saker eller situasjoner for Våre studenter som ikke kan utsettes til den årlige generalforsamling.
+	a. Ekstraordinær Generalforsamling skal arrangeres når Hovedstyret mener at det foreligger saker eller situasjoner for Våre studenter som ikke kan utsettes til den årlige ordinære generalforsamling.
 
-	b. Det kan også innkalles til generalforsamling når minst ti -10- personer krever det eller ett medlem av Hovedstyret krever det.
+	b. Det kan også innkalles til generalforsamling når minst ti -10- av Våre studenter krever det eller ett medlem av Hovedstyret krever det.
 
 ## § 10 Organisasjonsform
 1. echo er en frittstående juridisk person med medlemmer, og er selveiende. At echo er selveiende innebærer at ingen, verken medlemmer eller andre, har krav på echos formue eller eiendeler, eller er ansvarlig for gjeld eller andre forpliktelser.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -123,15 +123,17 @@ Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 1. Generalforsamling er organisasjonens høyeste organ.
 2. Det innkalles til generalforsamling med minst to -2- ukers varsel.
 3. Generalforsamlingen skal ha en dagsorden. Foreløpig dagsorden skal gjøres kjent for Våre studenter samtidig med innkalling.
-4. Vedtak fattes med simpelt flertall av de stemmeberettigede som er tilstede, forutsatt at antall stemmeberettigede overstiger tyve -20-.
-5. Forslag til saker som skal opp på generalforsamlingen må fremmes til Hovedstyret minst fire -4- virkedager før generalforsamlingen skal holdes.
-6. Tre -3- virkedager før generalforsamlingen skal endelig dagsorden offentliggjøres.
-7. Ordinær generalforsamling
+4. Generalforsamlingen kan ikke behandle forslag som ikke er oppført på sakslisten, med
+   mindre det blir godkjent av et alminnelig flertall av de stemmeberettigede som er tilstede.
+5. Vedtak fattes med simpelt flertall av de stemmeberettigede som er tilstede, forutsatt at antall stemmeberettigede overstiger tyve -20-.
+6. Forslag til saker som skal opp på generalforsamlingen må fremmes til Hovedstyret minst fire -4- virkedager før generalforsamlingen skal holdes.
+7. Tre -3- virkedager før generalforsamlingen skal endelig dagsorden offentliggjøres.
+8. Ordinær generalforsamling
 
 	a. Det skal innkalles til minst én -1- generalforsamling i året, i forbindelse med §5 Valg
 
 	b. Generalforsamlingen skal gjennomgå forvaltningen av organisasjonens økonomi.
-8. Ekstraordinær generalforsamling
+9. Ekstraordinær generalforsamling
 
 	a. Generalforsamling skal arrangeres når Hovedstyret mener at det foreligger saker eller situasjoner for Våre studenter som ikke kan utsettes til den årlige generalforsamling.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -53,7 +53,7 @@ Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 
 	c. Vedtak fattes ved simpelt flertall. Ved stemmelikhet har leder dobbeltstemme.
 
-	d. Alle Hovedstyrets møter skal protokollføres, og protokollen skal offentliggjøres. Protokollen skal offentliggjøres innen neste hovedstyremøte. Hovedstyret forbeholder seg retten til å unnta saker av sensitiv grad fra den offentlige protokollen, det skal inngå i referater at saker har blitt unntatt offentligheten.
+	d. Alle Hovedstyrets møter skal ha referater, og referatet skal offentliggjøres. Referatet skal offentliggjøres innen neste hovedstyremøte. Hovedstyret forbeholder seg retten til å unnta saker av sensitiv grad fra det offentlige referatet, det skal inngå i referatet at saker har blitt unntatt offentligheten.
 
 	e. En representant fra hver av echos undergrupper har møterett på Hovedstyrets møter.
 
@@ -122,12 +122,12 @@ Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 ## § 9 Generalforsamling
 1. Generalforsamling er organisasjonens høyeste organ.
 2. Det innkalles til generalforsamling med minst to -2- ukers varsel.
-3. Generalforsamlingen skal ha en dagsorden. Foreløpig dagsorden skal gjøres kjent for Våre studenter samtidig med innkalling.
+3. Generalforsamlingen skal ha en saksliste. Foreløpig saksliste skal gjøres kjent for Våre studenter samtidig med innkalling.
 4. Generalforsamlingen kan ikke behandle forslag som ikke er oppført på sakslisten, med
    mindre det blir godkjent av et alminnelig flertall av de stemmeberettigede som er tilstede.
 5. Vedtak fattes med simpelt flertall av de stemmeberettigede som er tilstede, forutsatt at antall stemmeberettigede overstiger tyve -20-.
 6. Forslag til saker som skal opp på generalforsamlingen må fremmes til Hovedstyret minst fire -4- virkedager før generalforsamlingen skal holdes.
-7. Tre -3- virkedager før generalforsamlingen skal endelig dagsorden offentliggjøres.
+7. Tre -3- virkedager før generalforsamlingen skal endelig saksliste offentliggjøres.
 8. Ordinær generalforsamling
 
 	a. Det skal innkalles til minst én -1- generalforsamling i året, i forbindelse med §5 Valg

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -81,19 +81,21 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 echo har ingen medlemskontingent.
 
 ## § 6 Hovedstyret
-Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
+Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes, og skal gjennomføre vedtak fattet av generalforsamlingen.
 
 1. Styret
 	
 	a. Hovedstyret består av de folkevalgte og én -1- undergruppe-Rep fra hver av echo sine undergrupper.
 	
-	b. Det avholdes valg av representant internt i undergruppene etter valgresultatene før de folkevalgte er offentliggjort.
+	b. I forbindelse med det ordinære valget skal det velges en undergrupper-rep fra hver undergruppe. undergrupper-Rep skal velges etter offentliggjøringen av valgresultatet, og senest innen én - 1 - uke.
 	
 	c. En person kan ikke være undergruppe-Rep for mer enn én -1- undergruppe. De folkevalgte kan ikke være undergruppe-Rep.
 	
-	d. Det er kun de folkevalgte som kan velges inn som leder, nestleder, økonomiansvarlig og økonomiassistent.
+	d. Det er kun de folkevalgte som kan velges inn som leder, nestleder, økonomiansvarlig.
 
-	e. Hvis noen av kandidatene som blir valgt inn som hovedstyremedlem sitter i en undergruppe kan vedkomne selv velge å ta pause fra vervet sitt i undergruppen. Representanten kan returnere til vervet sitt etter styreperioden er over. Representanten skal bli invitert til sosiale sammenkomster i undergruppen.
+	e. Hovedstyret oppretter roller etter behov.
+
+	f. Hovedstyret kan ved alminnelig flertall avsette en leder fra en undergruppe.
 
 2. Styremøte
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -1,3 +1,25 @@
+## § 0 Definisjoner
+I disse vedtektene betyr
+1. echo
+
+   echo - Linjeforening for informatikk, org.nr.: 998995035.
+
+2. Våre studenter
+
+   Personer som oppfyller minst ett -1- av punktene i § 2 Medlemmer..
+
+3. Instituttet
+
+   Institutt for informatikk ved Universitetet i Bergen
+
+4. Fakultetet
+
+   Fakultet for naturvitenskap og teknologi ved Universitetet i Bergen.
+
+5. Programmerbar
+
+   echo Programmerbar, org.nr.: 927307898.
+
 ## § 1 Foreningens navn
 
 Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Foreningen kan i dagligtale og skriftlige referanser forkortes til "echo" (med liten e). I disse vedtektene vil foreningen refereres til som "echo".
@@ -5,17 +27,17 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 ## § 2 Medlemmer
 Studenter som oppfyller minst ett -1- av følgende punkter regnes som “Våre studenter”::
 
-1. Programstudenter ved Institutt for informatikk ved Universitetet i Bergen.
-2. Post-bachelorstudenter og post-masterstudenter som tidligere har vært programstudenter ved Institutt for informatikk ved Universitetet i Bergen, og som fremdeles tar emne(r) ved nevnt institutt.
-3. Ph.d.-kandidater ved Institutt for informatikk ved Universitetet i Bergen som tidligere har vært programstudenter ved Institutt for informatikk ved Universitetet i Bergen. Ved gode grunner kan hovedstyret tillate andre Ph.d.-kandidater.
-4. Ved gode grunner kan hovedstyret tillate andre studenter, dersom de tar hovedemner ved Institutt for informatikk ved Universitetet i Bergen.
+1. Programstudenter ved Instituttet.
+2. Post-bachelorstudenter og post-masterstudenter som tidligere har vært programstudenter ved Instituttet, som har betalt semesteravgift og tar emne(r).
+3. Ph.d.-kandidater ved Instituttet som tidligere har vært programstudenter ved Instituttet. Ved gode grunner kan hovedstyret tillate andre Ph.d.-kandidater.
+4. Ved gode grunner kan Hovedstyret tillate andre studenter, dersom de tar hovedemner ved Instituttet.
 
 ## § 3 Formål
 
 1. echo har som hovedformål å ivareta og fremme interessene til Våre studenter.
 2. echo skal aktivt arbeide for å opprettholde og forbedre et høyt faglig og sosialt studiemiljø for Våre studenter.
-3. echo skal være en effektiv representant for Våre studenter ovenfor Institutt for informatikk og Fakultetet for naturvitenskap og teknologi ved Universitetet i Bergen, for å sikre studienes kvalitet og relevans.
-4. echo skal være et aktivt bindeledd mellom Våre studenter og næringslivet som har relevans i forbindelse med Institutt for informatikk ved Universitetet i Bergen.
+3. echo skal være en effektiv representant for Våre studenter overfor Instituttet og Fakultetetet, for å sikre studienes kvalitet og relevans.
+4. echo skal være et aktivt bindeledd mellom Våre studenter og næringslivet som har relevans i forbindelse med Instituttet.
 5. echo skal tilstrebe samarbeid med andre studentorganisasjoner.
 
 ## § 4 Rettigheter og plikter knyttet til medlemskapet
@@ -154,7 +176,7 @@ Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 	1. ESC skal fungere som et bindeledd mellom flere idrettslag under echo, slik at det skal bli lettere å forme ulike idrettsgrupper.
 	2. ESC skal arrangere treninger og holde kurs.
 3. Gnist
-	1. Gnist arbeider med rekruttering og fullføring av studiet i samarbeid med Institutt for informatikk- og Det matematisk-naturvitenskapelige fakultet ved Universitetet i Bergen.
+	1. Gnist arbeider med rekruttering og fullføring av studiet i samarbeid med Instituttet og Fakultetet.
 	2. Gnist arrangerer diverse faglige og sosiale arrangementer for Våre studenter.
 4. Hyggkom
 	1. Hyggkom fokuserer på å skape trivsel på lesesalene våre.
@@ -181,7 +203,7 @@ Leder og ett annet styremedlem kan signere sammen.
 
 ## § 14 Oppløsning
 
-Oppløsning skjer dersom Linjeforeningen er uten styremedlemmer i mer enn 6 måneder. Eventuelle eiendeler skal da overføres til Institutt for informatikk ved UiB.
+Oppløsning skjer dersom Linjeforeningen er uten styremedlemmer i mer enn 6 måneder. Eventuelle eiendeler skal da overføres til Instituttet.
 
 ## § 15 Økonomi
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -227,15 +227,15 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 Opptak:
 
-	1. Våre studenter skal informeres minst én -1- uke før søknadsfristen for opptak til verv i en undergruppe.
+1. Våre studenter skal informeres minst én -1- uke før søknadsfristen for opptak til verv i en undergruppe.
 
-	2. Medlemmer kan gjenoppta sine verv i en undergruppe etter fravær grunnet ekstraordinære omstendigheter eller utveksling. Gjenopptakelsen må godkjennes av styret til undergruppen.
+2. Medlemmer kan gjenoppta sine verv i en undergruppe etter fravær grunnet ekstraordinære omstendigheter eller utveksling. Gjenopptakelsen må godkjennes av styret til undergruppen.
 
-   Rettigheter:
+Rettigheter:
 
-	1. Leder for en undergruppe har rett til å avsette medlemmer. Før dette skjer, skal vedkommende motta en skriftlig advarsel. Hovedstyret skal informeres om avsettelsen.
+1. Leder for en undergruppe har rett til å avsette medlemmer. Før dette skjer, skal vedkommende motta en skriftlig advarsel. Hovedstyret skal informeres om avsettelsen.
 
-	2. Medlemmer som har blitt avsatt, har rett til å anke til Hovedstyret.
+2. Medlemmer som har blitt avsatt, har rett til å anke til Hovedstyret.
 
 echo sine undergrupper, og deres formål:
 
@@ -246,7 +246,7 @@ echo sine undergrupper, og deres formål:
 2. echo Consulting
    1. echo Consulting skal utvikle webløsninger for eksterne organisasjoner, primært
       frivillige- og studentorganisasjoner.
-      2. echo Consulting skal bidra til et sterkt fagmiljø blant Våre studenter, med blant annet
+   2. echo Consulting skal bidra til et sterkt fagmiljø blant Våre studenter, med blant annet
          arrangementer eller relevante kurs.
 3. echo Sports Club (ESC)
 	1. ESC skal fungere som et bindeledd mellom flere idrettslag under echo, slik at det skal bli lettere å forme ulike idrettsgrupper.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -166,29 +166,36 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 ## § 8 Valg
 1. Det avholdes valg til Hovedstyret hver vår i forbindelse med generalforsamling. Her velges syv -7- kandidater gjennom preferansevalg.
-2. Valgresultat
+2. Algoritmen som blir brukt er single transferable vote (STV).
+3. Valgresultat
 
-	a. Valgresultatet skal offentliggjøres som en alfabetisk liste bestående av de folkevalgte. Liste over resterende kandidater som stilte til valg publiseres i alfabetisk rekkefølge.
+	a. Valgresultatet skal offentliggjøres som en alfabetisk liste bestående av de folkevalgte. Liste over resterende kandidater som stilte til valg skal publiseres i alfabetisk rekkefølge. Valgresultatet utover de folkevalgte er taushetsbelagt, og skal oppbevares av en tredjepart uavhengig av echo.
 
-	b. Valgresultatet utover de folkevalgte er taushetsbelagt, og skal oppbevares av en tredjepart uavhengig av echo.
+	b. Innsyn kan gis til personer i og utenfor Hovedstyret, og må vedtas med 2/3 kvalifisert flertall på et Hovedstyremøte. Disse personene er underlagt taushetsplikt. Dersom begjæringen om innsyn ikke vedtas av Hovedstyret, kan søker kreve at saken tas opp på neste generalforsamling.
 
-	c. Innsyn kan gis til personer i og utenfor Hovedstyret, og må vedtas med 2/3 kvalifisert flertall på styremøte. Disse personene er underlagt taushetsplikten. Dersom begjæringen om innsyn ikke vedtas av Hovedstyret, kan søker kreve at saken tas opp på neste generalforsamling.
+4. Gjennomføring av et valg
 
-3. Tidspunkter
+	a. Alle stemmeberettigede skal få instrukser på hvordan en kan stemme. Det skal være mulig å stemme i minst førtiåtte -48- timer.
+   
+	b. Resultatet av valget skal senest bli publisert en uke etter at det først er mulig å stemme. 
 
-	a. Det skal avholdes ordinær generalforsamling siste uken av februar, det kan flyttes opp til to -2- uker dersom Hovedstyret ser dette som hensiktsmessig.
-
-	b. Valget kan ikke være mer enn én -1- måned.
-
-	c. Det nye Hovedstyret trer i kraft fra og med én -1- måned etter valget, datoen kan flyttes opp til to -2- uker hvis Hovedstyret ser dette som hensiktsmessig.
+	c. Hovedstyret plikter seg til å promotere kandidater som har stilt til valg minst én -1- uke før stemmingen åpner.
 
 	d. Nåværende Hovedstyret blir sittende frem til det påfølgende Hovedstyret trer i kraft.
 
-4. Ekstraordinært
+5. Ordinært
 
-	a. Et ekstraordinært valg kan kun innkalles av en generalforsamling, eller gjennom (Mistillits paragraf)§ 7.3.
+	a. Det skal gjennomføres et ordinært valg per år.
 
-	b. Innvalgte fra et ekstraordinært valg blir det nye Hovedstyret.
+	b. Valget skal fullføres to -2- uker etter den ordinære generalforsamlingen, datoen kan flyttes opp til én -1- uke hvis Hovedstyret ser dette som hensiktsmessig.
+
+	c. Det nye Hovedstyret trer i kraft fra og med én -1- måned etter at valgresultatet er publisert, datoen kan flyttes opp til to -2- uker hvis Hovedstyret ser dette som hensiktsmessig.
+
+6. Ekstraordinært 
+
+	a. Et ekstraordinært valg kan kun innkalles av en generalforsamling, eller gjennom § 7 Mistillit.
+   
+	b. Det nye Hovedstyret trer i kraft innen to -2- uker etter at valgresultatet er publisert.
 
 ## § 9 Generalforsamling
 1. Generalforsamling er organisasjonens høyeste organ.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -67,6 +67,7 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 4. echo skal være et aktivt bindeledd mellom Våre studenter og næringslivet som har relevans i forbindelse med Instituttet.
 5. echo skal tilstrebe samarbeid med andre studentorganisasjoner.
 6. echo skal tilby og drifte et makerspace.
+7. echo skal forvalte lesesalene tilhørende Instituttet.
 
 ## § 4 Rettigheter og plikter knyttet til medlemskapet
 1. Våre studenter har rett til å delta på generalforsamlinger, er stemmeberettigede og kan stille til valg i Hovedstyret.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -221,7 +221,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 1. echo er en frittstående juridisk person med medlemmer, og er selveiende. At echo er selveiende innebærer at ingen, verken medlemmer eller andre, har krav på echos formue eller eiendeler, eller er ansvarlig for gjeld eller andre forpliktelser.
 2. echo har undergrupper som bidrar hovedsakelig til å opprettholde § 3 Formål. echos undergrupper og deres relevante fagområder er definert i § 11 Undergrupper.
 3. echos undergrupper skal kun bestå av Våre studenter.
-4. echo har “echo Programmerbar” som underorganisasjon. echo sitt hovedstyret og “echo Programmerbar” sitt hovedstyret har gjensidig møterett i styremøtene til hverandre.
+4. echo har “echo Programmerbar” som underorganisasjon. Leder i Hovedstyret og Programmerbar har gjensidig møterett i styremøtene til hverandre. Leder i de respetive organisasjonene kan utnevne en stedfortreder.
 
 ## § 11 Undergrupper
 1. Bedriftskomitéen (Bedkom)

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -76,7 +76,6 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 4. Våre studenter kan kreve innsyn i echos regnskap og kan få innsyn i ikke-konfidensielle vedtak.
 5. Det er kun Våre studenter som kan fremme mistillit som definert i § 7.
 6. I forbindelse med echo, plikter Våre studenter å forholde seg til vedtak og retningslinjer fattet av generalforsamlingen og Hovedstyret.
-7. Våre studenter plikter å forholde seg til arrangementspesifikke retningslinjer.
 
 ## § 5 Kontingent
 echo har ingen medlemskontingent.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -109,7 +109,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 	e. En representant fra hver av echos undergrupper har møterett på Hovedstyrets møter.
 
-	f. Studentrepresentantene i instituttrådet har møterett i Hovedstyret. De plikter også å holde Hovedstyret orientert om saker i instituttrådet.
+	f. undergrupper-Rep kan gi fullmakt til verv-kamerat for å stemme.
 
 3. Vervet
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -208,9 +208,10 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 7. Tre -3- virkedager før generalforsamlingen skal endelig saksliste offentliggjøres.
 8. Ordinær generalforsamling
 
-	a. Det skal innkalles til minst én -1- generalforsamling i året, i forbindelse med §5 Valg
+	a. Det skal avholdes ordinær generalforsamling siste uken av februar, det kan flyttes opp til to -2- uker dersom Hovedstyret ser dette som hensiktsmessig.
 
 	b. Generalforsamlingen skal gjennomgå forvaltningen av organisasjonens økonomi.
+
 9. Ekstraordinær generalforsamling
 
 	a. Generalforsamling skal arrangeres når Hovedstyret mener at det foreligger saker eller situasjoner for Våre studenter som ikke kan utsettes til den årlige generalforsamling.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -72,10 +72,10 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 ## § 4 Rettigheter og plikter knyttet til medlemskapet
 1. Våre studenter har rett til å delta på generalforsamlinger, er stemmeberettigede og kan stille til valg i Hovedstyret.
 2. Våre studenter har rett til å delta på alle arrangementer holdt av echo, gitt at de er i arrangementets målgruppe.
-3. Våre studenter har rett til å søke om økonomiske midler som brukes i samsvar med § 3.
+3. Våre studenter har rett til å søke om økonomiske midler som brukes i samsvar med § 3 Formål.
 4. Våre studenter kan kreve innsyn i echos regnskap og kan få innsyn i ikke-konfidensielle vedtak.
 5. Det er kun Våre studenter som kan fremme mistillit som definert i § 7.
-6. Våre studenter plikter å forholde seg til vedtak som er fattet av generalforsamlingen.
+6. I forbindelse med echo, plikter Våre studenter å forholde seg til vedtak og retningslinjer fattet av generalforsamlingen og Hovedstyret.
 7. Våre studenter plikter å forholde seg til arrangementspesifikke retningslinjer.
 
 ## § 5 Kontingent

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -224,6 +224,21 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 4. echo har “echo Programmerbar” som underorganisasjon. Leder i Hovedstyret og Programmerbar har gjensidig møterett i styremøtene til hverandre. Leder i de respetive organisasjonene kan utnevne en stedfortreder.
 
 ## § 11 Undergrupper
+
+Opptak:
+
+	1. Våre studenter skal informeres minst én -1- uke før søknadsfristen for opptak til verv i en undergruppe.
+
+	2. Medlemmer kan gjenoppta sine verv i en undergruppe etter fravær grunnet ekstraordinære omstendigheter eller utveksling. Gjenopptakelsen må godkjennes av styret til undergruppen.
+
+   Rettigheter:
+
+	1. Leder for en undergruppe har rett til å avsette medlemmer. Før dette skjer, skal vedkommende motta en skriftlig advarsel. Hovedstyret skal informeres om avsettelsen.
+
+	2. Medlemmer som har blitt avsatt, har rett til å anke til Hovedstyret.
+
+echo sine undergrupper, og deres formål:
+
 1. Bedriftskomitéen (Bedkom)
 	1. Bedkom skal tilby hjelp med planlegging, markedsføring og organisering av ulike arrangementer for bedrifter i samråd med hovedstyret.
 	2. Bedkom skal bedre relasjonen mellom Våre studenter og næringslivet.
@@ -245,6 +260,7 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 	3. Hyggkom har hovedansvar for feiring av diverse høytider.
 6. Tilde
 	1. Tilde skal arrangere og gjennomføre sosiale arrangementer.
+    2. Tilde har ansvar for å arrangere vinterball.
 7. Webkom
 	1. Webkom drifter og videreutvikler echo sine webløsninger, hovedsakelig nettsiden echo.uib.no
 	2. Webkom skal holde relevante kurs og arrangementer.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -130,29 +130,39 @@ Hovedstyrets hovedoppgave er å sørge for at echo sine vedtekter opprettholdes,
 
 1. Et mistillitsforslag kan fremmes dersom ett eller flere av følgende punkter er oppfylt
 
-	a. Personen(e) har vesentlig forsømt sine oppgaver som representant i hovedstyret.
+	a. Representanten(e) har vesentlig forsømt sine oppgaver som representant i Hovedstyret.
 
-	b. Personen(e) har brutt utvalgets vedtekter.
+	b. Representanten(e) har brutt echo sine vedtekter.
 
-	c. Personen(e) har brutt norsk lov iht. utføring av vervets oppgaver.
+	c. Representanten(e) har brutt norsk lov iht. utføring av vervets oppgaver.
 
-2. Mistillit mot ett -1- medlem i hovedstyret
+2. Gjennomføring og konsekvenser av mistillitsforslag
 
-	a. Et mistillitsforslag fremmes ved en skriftlig henvendelse til et hovedstyremedlem av en av Våre studenter.
+   a. Et mistillitsforslag fremmes ved en skriftlig henvendelse, med begrunnelse, til en representant i Hovedstyret.
+
+   b. Voteringen er anonym, og det er nødt til å være en nøytral tredjepart, som ikke er en del av echo, som teller stemmene.
+
+   c. Hvis mistillitsforslaget blir vedtatt mister representant(e) plassen sin i Hovedstyret. 
+
+	De som vedtok mistillitsforslaget er nødt til å bestemme hvordan representanten(e) blir erstattet.
+
+3. Mistillit mot én -1- representant i Hovedstyret
+
+	a. En av Våre studenter kan stille mistillitsforslag til en representant i Hovedstyret.
 
 	b. Hovedstyret er nødt til å behandle mistillitsforslaget innen to -2- uker.
 
-	c. Et slikt mistillitsforslag vil bli behandlet av hovedstyret på et hovedstyremøte. De involverte partene presenterer saken sin ved ønske, de involverte må forlate rommet under diskusjon og avstemming. Denne avstemningen er anonym, og det er nødt til å være en tredjepart, som ikke er en del av echo, som teller stemmene.
+	c. Et slikt mistillitsforslag vil bli behandlet av Hovedstyret på et Hovedstyremøte. De involverte partene presenterer saken sin ved ønske, de involverte må forlate rommet under diskusjon og avstemming. Denne avstemningen er anonym, og det er nødt til å være en tredjepart, som ikke er en del av echo, som teller stemmene.
 
 	d. Hvis mistillitsforslaget blir vedtatt med 2/3 kvalifisert flertall mister personen plassen sin i styret.
 
-3. Mistillitsforslag mot mer enn ett -1- medlem i hovedstyret
+4. Mistillitsforslag mot mer enn én -1- representant i Hovedstyret
 
-	a. Et mistillitsforslag fremmes ved en skriftlig henvendelse til et hovedstyremedlem med minst ti -10- unike signaturer og navn fra Våre studenter.
+	a. Ved ti -10- unike signaturer, med tilhørende navn, fra Våre studenter kan det bli stilt et mistillitsforslag til mer enn én -1- representant i Hovedstyret.
 
-	b. Dersom det fremmes mistillitsforslag mot mer enn ett -1- hovedstyremedlem skal det bli kalt inn til ekstraordinær generalforsamling i henhold til §9. Mistillitsforslaget vil være den eneste saken på sakslisten. Denne avstemningen er anonym.
+	b. Det skal da bli kalt inn til ekstraordinær generalforsamling i henhold til §9 Generalforsamling. Mistillitsforslaget vil være den eneste saken på sakslisten.
 
-	c. Hvis mistillitsforslaget blir vedtatt med simpelt flertall, skal det bli avholdt ekstraordinært valg i henhold til § 8.4. Hovedstyret er nødt til å gå av innen to -2- uker.
+   c. Det kreves alminnelig flertall blant de tilstedeværende stemmeberettigede for at mistillitsforslaget blir vedtatt.
 
 ## § 8 Valg
 1. Det avholdes valg til Hovedstyret hver vår i forbindelse med generalforsamling. Her velges syv -7- kandidater gjennom preferansevalg.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -22,11 +22,9 @@ I disse vedtektene betyr
 
 ## § 1 Foreningens navn
 
-Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Foreningen kan i dagligtale og skriftlige referanser forkortes til "echo" (med liten e). I disse vedtektene vil foreningen refereres til som "echo".
+Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Foreningen kan i dagligtale og skriftlige referanser forkortes til "echo" (med liten e).
 
 ## § 2 Medlemmer
-Studenter som oppfyller minst ett -1- av følgende punkter regnes som “Våre studenter”::
-
 1. Programstudenter ved Instituttet.
 2. Post-bachelorstudenter og post-masterstudenter som tidligere har vært programstudenter ved Instituttet, som har betalt semesteravgift og tar emne(r).
 3. Ph.d.-kandidater ved Instituttet som tidligere har vært programstudenter ved Instituttet. Ved gode grunner kan hovedstyret tillate andre Ph.d.-kandidater.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -14,7 +14,7 @@ Studenter som oppfyller minst ett -1- av følgende punkter regnes som “Våre s
 
 1. echo har som hovedformål å ivareta og fremme interessene til Våre studenter.
 2. echo skal aktivt arbeide for å opprettholde og forbedre et høyt faglig og sosialt studiemiljø for Våre studenter.
-3. echo skal være en effektiv representant for Våre studenter ovenfor Institutt for informatikk og Det matematisk-naturvitenskapelige fakultet ved Universitetet i Bergen, for å sikre studienes kvalitet og relevans.
+3. echo skal være en effektiv representant for Våre studenter ovenfor Institutt for informatikk og Fakultetet for naturvitenskap og teknologi ved Universitetet i Bergen, for å sikre studienes kvalitet og relevans.
 4. echo skal være et aktivt bindeledd mellom Våre studenter og næringslivet som har relevans i forbindelse med Institutt for informatikk ved Universitetet i Bergen.
 5. echo skal tilstrebe samarbeid med andre studentorganisasjoner.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -281,4 +281,8 @@ Oppløsning skjer dersom Linjeforeningen er uten styremedlemmer i mer enn 6 mån
 
 ## § 15 Økonomi
 
-Hovedstyret skal drive foreningen på en bærekraftig og ansvarlig måte for nåværende og fremtidige generasjoner. Hovedstyret plikter seg å sette opp minst et budsjett per semester. Budsjettet skal ikke gå med underskudd med mindre hovedstyret gjør en investering for fremtidige generasjoner eller hovedstyret ser det som ansvarlig.
+1. Hovedstyret skal drive foreningen på en bærekraftig og ansvarlig måte for nåværende og fremtidige generasjoner. 
+2. Hver undergruppe plikter seg å sette opp et budsjett og føre regnskap for hvert semester.
+3. Hovedstyret plikter å sette opp et budsjett og føre regnskap for hvert semester.
+4. Undergruppene skal sende inn et førsteutkast av budsjettet til Hovedstyret i forkant av hvert semester. Hovedstyret vil deretter gi tilbakemelding, slik at nødvendige justeringer kan gjøres før budsjettet godkjennes i begynnelsen av det nye semesteret.
+5. Budsjettet skal ikke gå med underskudd med mindre hovedstyret gjør en investering for fremtidige generasjoner eller hovedstyret ser det som ansvarlig.

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -66,6 +66,7 @@ Foreningens offisielle navn er "echo - Linjeforeningen for informatikk". Forenin
 3. echo skal være en effektiv representant for Våre studenter overfor Instituttet og Fakultetetet, for å sikre studienes kvalitet og relevans.
 4. echo skal være et aktivt bindeledd mellom Våre studenter og næringslivet som har relevans i forbindelse med Instituttet.
 5. echo skal tilstrebe samarbeid med andre studentorganisasjoner.
+6. echo skal tilby og drifte et makerspace.
 
 ## § 4 Rettigheter og plikter knyttet til medlemskapet
 1. Våre studenter har rett til å delta på generalforsamlinger, er stemmeberettigede og kan stille til valg i Hovedstyret.
@@ -209,12 +210,9 @@ Hovedstyret skal sørge for at echo sine vedtekter opprettholdes.
 	1. Hyggkom fokuserer på å skape trivsel på lesesalene våre.
 	2. Hyggkom har et overordnet ansvar for forvaltning av lesesalene våre.
 	3. Hyggkom har hovedansvar for feiring av diverse høytider.
-5. Makerspace
-	1. Makerspace har et overordnet ansvar for forvaltning av Makerspace-rommet.
-	2. Makerspace skal holde relevante kurs og arrangementer.
-6. Tilde
+5. Tilde
 	1. Tilde skal arrangere og gjennomføre sosiale arrangementer.
-7. Webkom
+6. Webkom
 	1. Webkom drifter og videreutvikler echo sine webløsninger, hovedsakelig nettsiden echo.uib.no
 	2. Webkom skal holde relevante kurs og arrangementer.
 

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -174,7 +174,7 @@ Leder og ett annet styremedlem kan signere sammen.
 ## § 13 Vedtektsendring
 
 1. Disse vedtektene gjelder fra 7/11-95. Den sittende linjeforening har ansvaret for iverksettelsen av disse vedtektene. Disse vedtektene kan kun endres på en generalforsamling ved Institutt for informatikk på Universitetet i Bergen. Et vedtak om en endring må ha oppnådd 2/3 flertall blant de tilstedeværende stemmeberettigede.
-2. Vedtektene ble sist endret ved generalforsamling 27.02.2023.
+2. Vedtektene ble sist endret ved generalforsamling 04.03.2024.
 3. Hovedstyret har til enhver tid myndighet til å gjøre redaksjonelle endringer i echo sine vedtekter. En redaksjonell endring er en endring vedrørende grammatikk, struktur eller ordlyd som ikke forandrer på meningen eller innholdet i originalteksten. Eventuelle endringer må protokollføres, og informeres om under neste generalforsamling.
 
 ## § 14 Oppløsning

--- a/vedtekter.md
+++ b/vedtekter.md
@@ -34,56 +34,89 @@ echo har ingen medlemskontingent.
 Hovedstyret skal sørge for at organisasjonens vedtekter opprettholdes.
 
 1. Styret
+	
 	a. Hovedstyret består av de folkevalgte og én -1- representant fra hver av echos undergrupper.
+	
 	b. Det avholdes valg av representant internt i undergruppene etter valgresultatene før de folkevalgte er offentliggjort.
+	
 	c. En person kan ikke representere mer enn én -1- undergruppe. De folkevalgte kan ikke være representant for en undergruppe.
+	
 	d. Det er kun de folkevalgte som kan velges inn som leder, nestleder, økonomiansvarlig og økonomiassistent.
 
-e. Hvis noen av kandidatene som blir valgt inn som hovedstyremedlem sitter i en undergruppe kan vedkomne selv velge å ta pause fra vervet sitt i undergruppen. Representanten kan returnere til vervet sitt etter styreperioden er over. Representanten skal bli invitert til sosiale sammenkomster i undergruppen.
+	e. Hvis noen av kandidatene som blir valgt inn som hovedstyremedlem sitter i en undergruppe kan vedkomne selv velge å ta pause fra vervet sitt i undergruppen. Representanten kan returnere til vervet sitt etter styreperioden er over. Representanten skal bli invitert til sosiale sammenkomster i undergruppen.
 
 2. Styremøte
+
 	a. Hovedstyret avgjør selv møtehyppigheten.
+
 	b. Hovedstyret er vedtaksdyktig dersom mer enn 50% av utvalgets medlemmer er tilstede.
+
 	c. Vedtak fattes ved simpelt flertall. Ved stemmelikhet har leder dobbeltstemme.
+
 	d. Alle Hovedstyrets møter skal protokollføres, og protokollen skal offentliggjøres. Protokollen skal offentliggjøres innen neste hovedstyremøte. Hovedstyret forbeholder seg retten til å unnta saker av sensitiv grad fra den offentlige protokollen, det skal inngå i referater at saker har blitt unntatt offentligheten.
+
 	e. En representant fra hver av echos undergrupper har møterett på Hovedstyrets møter.
+
 	f. Studentrepresentantene i instituttrådet har møterett i Hovedstyret. De plikter også å holde Hovedstyret orientert om saker i instituttrådet.
 
 3. Vervet
+
 	a. Representanter kan trekke seg fra sitt verv i Hovedstyret dersom det er særskilt grunn.
+
 	b. Hvis en representant trekker seg fra Hovedstyrets kandidatliste, skal valgalgoritmen kjøres på nytt igjen med stemmene fra foregående valg. Personen som trakk seg fjernes fra stemmesedlene, og kandidater med lavere rangering enn den som trakk seg vil da rykke opp. I det tilfelle der det nye resultatet har mer enn ett nytt styremedlem vil stemmene på alle andre kandidater enn de aktuelle personene fjernes. En kjører så algoritmen en tredje gang der kun én kandidat utnevnes. Denne kandidaten overtar for personen som trakk seg.
 
 ## § 7 Mistillit
 
 1. Et mistillitsforslag kan fremmes dersom ett eller flere av følgende punkter er oppfylt
+
 	a. Personen(e) har vesentlig forsømt sine oppgaver som representant i hovedstyret.
+
 	b. Personen(e) har brutt utvalgets vedtekter.
+
 	c. Personen(e) har brutt norsk lov iht. utføring av vervets oppgaver.
+
 2. Mistillit mot ett -1- medlem i hovedstyret
+
 	a. Et mistillitsforslag fremmes ved en skriftlig henvendelse til et hovedstyremedlem av en av Våre studenter.
+
 	b. Hovedstyret er nødt til å behandle mistillitsforslaget innen to -2- uker.
+
 	c. Et slikt mistillitsforslag vil bli behandlet av hovedstyret på et hovedstyremøte. De involverte partene presenterer saken sin ved ønske, de involverte må forlate rommet under diskusjon og avstemming. Denne avstemningen er anonym, og det er nødt til å være en tredjepart, som ikke er en del av echo, som teller stemmene.
+
 	d. Hvis mistillitsforslaget blir vedtatt med 2/3-flertall mister personen plassen sin i styret.
 
 3. Mistillitsforslag mot mer enn ett -1- medlem i hovedstyret
+
 	a. Et mistillitsforslag fremmes ved en skriftlig henvendelse til et hovedstyremedlem med minst ti -10- unike signaturer og navn fra Våre studenter.
+
 	b. Dersom det fremmes mistillitsforslag mot mer enn ett -1- hovedstyremedlem skal det bli kalt inn til ekstraordinær generalforsamling i henhold til §9. Mistillitsforslaget vil være den eneste saken på sakslisten. Denne avstemningen er anonym.
+
 	c. Hvis mistillitsforslaget blir vedtatt med simpelt flertall, skal det bli avholdt ekstraordinært valg i henhold til § 8.4. Hovedstyret er nødt til å gå av innen to -2- uker.
 
 ## § 8 Valg
 1. Det avholdes valg til Hovedstyret hver vår i forbindelse med generalforsamling. Her velges syv -7- kandidater gjennom preferansevalg.
 2. Valgresultat
+
 	a. Valgresultatet skal offentliggjøres som en alfabetisk liste bestående av de folkevalgte. Liste over resterende kandidater som stilte til valg publiseres i alfabetisk rekkefølge.
+
 	b. Valgresultatet utover de folkevalgte er taushetsbelagt, og skal oppbevares av en tredjepart uavhengig av echo.
+
 	c. Innsyn kan gis til personer i og utenfor Hovedstyret, og må vedtas med 2/3 flertall på styremøte. Disse personene er underlagt taushetsplikten. Dersom begjæringen om innsyn ikke vedtas av Hovedstyret, kan søker kreve at saken tas opp på neste generalforsamling.
 
 3. Tidspunkter
+
 	a. Det skal avholdes ordinær generalforsamling siste uken av februar, det kan flyttes opp til to -2- uker dersom Hovedstyret ser dette som hensiktsmessig.
+
 	b. Valget kan ikke være mer enn én -1- måned.
+
 	c. Det nye Hovedstyret trer i kraft fra og med én -1- måned etter valget, datoen kan flyttes opp til to -2- uker hvis Hovedstyret ser dette som hensiktsmessig.
+
 	d. Nåværende Hovedstyret blir sittende frem til det påfølgende Hovedstyret trer i kraft.
+
 4. Ekstraordinært
+
 	a. Et ekstraordinært valg kan kun innkalles av en generalforsamling, eller gjennom (Mistillits paragraf)§ 7.3.
+
 	b. Innvalgte fra et ekstraordinært valg blir det nye Hovedstyret.
 
 ## § 9 Generalforsamling
@@ -94,10 +127,14 @@ e. Hvis noen av kandidatene som blir valgt inn som hovedstyremedlem sitter i en 
 5. Forslag til saker som skal opp på generalforsamlingen må fremmes til Hovedstyret minst fire -4- virkedager før generalforsamlingen skal holdes.
 6. Tre -3- virkedager før generalforsamlingen skal endelig dagsorden offentliggjøres.
 7. Ordinær generalforsamling
+
 	a. Det skal innkalles til minst én -1- generalforsamling i året, i forbindelse med §5 Valg
+
 	b. Generalforsamlingen skal gjennomgå forvaltningen av organisasjonens økonomi.
 8. Ekstraordinær generalforsamling
+
 	a. Generalforsamling skal arrangeres når Hovedstyret mener at det foreligger saker eller situasjoner for Våre studenter som ikke kan utsettes til den årlige generalforsamling.
+
 	b. Det kan også innkalles til generalforsamling når minst ti -10- personer krever det eller ett medlem av Hovedstyret krever det.
 
 ## § 10 Organisasjonsform


### PR DESCRIPTION
Gått gjennom alle saker som ble godkjent på generalforsmaling til echo i 2025.

---

Hver commit er en godkjent sak, så ta gjerne tiden å se gjennom dem om de stemmer med sakslisten/referatet.
Noen saker glemte jeg å legge/fjerne en linje, så det er noen saker som har flere commits.

Sakene som ikke ble godkjent var: 
- Sak 6.11 § 6.2 Hovedstyret
- Sak 6.16 Antall folkevalgte representanter
- Sak 6.21 Nynorsk formål
- Sak 6.22 Nynorsk formål
- Sak 6.23 Nynorsk formål

---

Sakslisten til generalforsmalingen kan man finner på generalforasmling arrangementet på echo sine nettsider:
[echo generalforsmaling 2025, Saksliste](https://echo.uib.no/arrangement/generalforsamling-2025)

Referatet til generalforsamlingen kan man finne på echo sin nettside under møtereferater:
[echo generalforsaing 2025, Referat](https://echo.uib.no/for-studenter/motereferat/19d1bef9-f900-47da-90ad-5ec5580fb46f)

---

**NB!** Se gjerne igjennom alle endringer some er blitt gjort for å dobbeltsjekke at de er riktige!